### PR TITLE
Added a conditional statement to set NameIDFormat

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -1222,7 +1222,10 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert, signi
     };
   }
 
-  metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = this.options.identifierFormat;
+  if (this.options.indentifierFormat) {
+    metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = this.options.identifierFormat;
+  }
+  
   metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = {
     '@index': '1',
     '@isDefault': 'true',


### PR DESCRIPTION
Added a conditional statement to set NameIDFormat only if identifierFormat is specified in options. This should prevent an error in AD FS when identifierFormat  set to null: https://github.com/bergie/passport-saml/issues/338